### PR TITLE
reorder logic in SetDefaults

### DIFF
--- a/MaxStackExtraItem.cs
+++ b/MaxStackExtraItem.cs
@@ -14,16 +14,19 @@ namespace MaxStackExtra
         {
             if (!(item.type == ItemID.CopperCoin || item.type == ItemID.SilverCoin || item.type == ItemID.GoldCoin || item.type == ItemID.PlatinumCoin))
             {
-                if (item.damage > 0 && item.ammo == 0 && !item.consumable)
-                    item.maxStack = mod.GetConfig<MaxStackExtraConfig>().WeaponStackValue;
-                else if (item.createTile > 0)
-                    item.maxStack = mod.GetConfig<MaxStackExtraConfig>().TileStackValue;
+                if (item.maxStack > 1)
+                {
+                    if (item.createTile > 0)
+                        item.maxStack = mod.GetConfig<MaxStackExtraConfig>().TileStackValue;
+                    else
+                        item.maxStack = mod.GetConfig<MaxStackExtraConfig>().ItemStackValue;
+                }
                 else if (item.accessory || item.defense > 0)
                     item.maxStack = mod.GetConfig<MaxStackExtraConfig>().EquipStackValue;
-                else if (!item.accessory && item.damage == 0 && item.defense == 0 && item.createTile == 0 && item.maxStack == 1)
+                else if (item.damage > 0)
+                    item.maxStack = mod.GetConfig<MaxStackExtraConfig>().WeaponStackValue;
+                else
                     item.maxStack = mod.GetConfig<MaxStackExtraConfig>().SpecialStackValue;
-                else if (item.maxStack > 1)
-                    item.maxStack = mod.GetConfig<MaxStackExtraConfig>().ItemStackValue;
             }
             else
                 base.SetDefaults(item);


### PR DESCRIPTION
Any item that stacks above 1 by default should be treated as a tile or an item.
Equipables should be checked before weapons because of items like the Shield of Cthulhu (an accessory with a damage value).
If it fails all these checks, then it is probably a special item.